### PR TITLE
Fix inputMethodQuery() signature as const

### DIFF
--- a/yat_declarative/terminal_screen.cpp
+++ b/yat_declarative/terminal_screen.cpp
@@ -32,7 +32,7 @@ Screen *TerminalScreen::screen() const
     return m_screen;
 }
 
-QVariant TerminalScreen::inputMethodQuery(Qt::InputMethodQuery query)
+QVariant TerminalScreen::inputMethodQuery(Qt::InputMethodQuery query) const
 {
     switch (query) {
     case Qt::ImEnabled:

--- a/yat_declarative/terminal_screen.h
+++ b/yat_declarative/terminal_screen.h
@@ -41,7 +41,7 @@ public:
 
     Screen *screen() const;
 
-    QVariant inputMethodQuery(Qt::InputMethodQuery query);
+    QVariant inputMethodQuery(Qt::InputMethodQuery query) const;
 
 protected:
     void inputMethodEvent(QInputMethodEvent *event);


### PR DESCRIPTION
Gets actually called when signature matches base class one.
